### PR TITLE
Improve 'Our Approach' card style

### DIFF
--- a/docs/css/components/home.css
+++ b/docs/css/components/home.css
@@ -569,17 +569,24 @@
   box-shadow: 0 15px 40px rgba(172, 130, 85, 0.2);
   position: relative;
   z-index: var(--z-normal);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.approach-card-inner:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 20px 50px rgba(172, 130, 85, 0.3);
 }
 
 .approach-card-shape {
   position: absolute;
   width: 200px;
   height: 200px;
-  background-color: rgba(172, 130, 85, 0.1);
+  background-color: rgba(172, 130, 85, 0.07);
   border-radius: 50%;
   top: -100px;
   right: -80px;
   z-index: var(--z-background);
+  filter: blur(2px);
 }
 
 .approach-card h3 {
@@ -604,16 +611,17 @@
 
 .step-number {
   flex-shrink: 0;
-  width: 30px;
-  height: 30px;
-  background-color: rgba(255, 255, 255, 0.2);
+  width: 40px;
+  height: 40px;
+  background: var(--gradient-light);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-right: 1rem;
   font-weight: 700;
-  color: white;
+  color: var(--primary-dark);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15);
 }
 
 .step-content {


### PR DESCRIPTION
## Summary
- add hover interactions and smoother shadow to the Our Approach card
- update step number styling with gradient and larger size
- soften the background accent circle

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f26c9530483228acf19c38eb183f4